### PR TITLE
Downgrade generator version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         // url "https://plugins.gradle.org/m2/"
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:6.6.0"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:6.0.1"
     }
 }
 
@@ -21,5 +21,5 @@ repositories {
 }
 
 dependencies {
-    implementation "org.openapitools:openapi-generator-gradle-plugin:6.6.0"
+    implementation "org.openapitools:openapi-generator-gradle-plugin:6.0.1"
 }

--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -59,6 +59,9 @@ project.ext.services.each { Service svc ->
         reservedWordsMappings.set([
                 "configuration": "configuration"
         ])
+        additionalProperties.set([
+                'serviceName': project.ext.serviceName,
+        ])
 
         if (project.ext.has('configFile')) {
             configFile.set("$projectDir/repo/$project.ext.configFile")

--- a/go/build.gradle
+++ b/go/build.gradle
@@ -28,9 +28,6 @@ tasks.withType(GenerateTask).configureEach {
             'apiDocs'        : 'false',
             'modelDocs'      : 'false'
     ])
-    additionalProperties.set([
-            'serviceName': project.ext.serviceName,
-    ])
 }
 
 // Deployment

--- a/php/build.gradle
+++ b/php/build.gradle
@@ -7,7 +7,7 @@ plugins {
 tasks.withType(GenerateTask).configureEach {
     modelPackage.set("Model\\${project.ext.serviceName}")
     apiPackage.set("Service\\${project.ext.serviceName}")
-    additionalProperties.set([
+    additionalProperties.putAll([
             'variableNamingConvention': 'camelCase',
             'invokerPackage'          : 'Adyen',
             'packageName'             : 'Adyen'


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Version 6.6.0 of the Python generator is terribly slow. Going back to [v6.0.1](https://github.com/Adyen/adyen-python-api-library/blob/e827badcdfceb2ae89122feed97f437a56078c29/Makefile#L12) because thats what we've been using and it works much faster. 

I've also setting `serviceName` globally. 