### PR TITLE
Generation of OpenAPI diffs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
         repository: Adyen/adyen-${{ matrix.project }}-api-library
         path: ${{ matrix.project }}/repo
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+      uses: gradle/gradle-build-action@v3
     - name: Override properties
       if: matrix.project == 'node'
       run: cp ${{ matrix.project }}/gradle.properties buildSrc
@@ -49,7 +49,7 @@ jobs:
         echo pr_body="OpenAPI spec or templates produced changes on $(date +%d-%m-%Y) \
           by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD))." >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+      uses: peter-evans/create-pull-request@v7
       with:
         path: ${{ matrix.project }}/repo
         token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,13 +41,57 @@ jobs:
       run: cp ${{ matrix.project }}/gradle.properties buildSrc
     - name: Generate code for ${{ matrix.project }}
       run: ./gradlew ${{ matrix.project }}:services
+    - name: OpenAPI diffs
+      id: openapi-diffs
+      run: |
+        cd schema
+        COMMIT_HASH=$(git rev-parse HEAD)
+        COMMIT_HASH_BEFORE=$(git rev-parse HEAD^)
+
+        echo "Generate OpenAPI diff between commits [$COMMIT_HASH_BEFORE, $COMMIT_HASH]"            
+
+        # save commit that has triggered the OpenAPI generation
+        echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
+
+        # Fetch files modified by the commit
+        files=$(git diff-tree --no-commit-id --name-only -r $COMMIT_HASH)
+
+        for file in $files; do
+          if [[ $file == *.json ]]; then
+            # get filename
+            filename="${file%.*}"
+            # checkout file before the commit
+            temp_before_name="${filename}_before.json"
+            git show $COMMIT_HASH_BEFORE:$file > $temp_before_name
+        
+            # checkout file after the commit
+            temp_after_name="${filename}_after.json"
+            git show $COMMIT_HASH:$file > $temp_after_name
+
+            docker run -v "$(pwd):/specs" --rm -t tufin/oasdiff diff \
+              -f markup \
+              /specs/$temp_before_name \
+              /specs/$temp_after_name \
+              >> "oas_diff_${filename//\//_}.md"
+            echo "$filename ✅"            
+
+          fi
+        done
+      # upload generated openapi-diff markdowns as artifacts
+    - uses: actions/upload-artifact@v4
+      id: artifact-upload-step
+      with:
+        name: openapi-diff files (commit ${{ env.COMMIT_HASH }})
+        path: |
+          schema/oas_diff_*.md
     - name: Set PR variables
       id: vars
       run: |
         cd schema
         echo pr_title="Update all services" >> "$GITHUB_OUTPUT"
         echo pr_body="OpenAPI spec or templates produced changes on $(date +%d-%m-%Y) \
-          by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD))." >> "$GITHUB_OUTPUT"
+          by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). \
+          Download [OpenAPI diffs](${{ steps.artifact-upload-step.outputs.artifact-url }}) to view the changes." >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ def checkoutDir = "$projectDir/schema/json/CheckoutService-v71.json"
 tasks.register('specs', Exec) {
     group 'setup'
     description 'Clone OpenAPI spec (and apply local patches).'
-    commandLine 'git', 'clone', '--depth', '1', uri, specsDir
+    commandLine 'git', 'clone', '--depth', '2', uri, specsDir
     outputs.dir specsDir
     onlyIf { !file(specsDir).exists() }
     doLast {


### PR DESCRIPTION
## Summary
This PR updates the GitHub workflow that (re)generates the SDK code, adding 2 additional steps:
- generate the OpenAPI diffs of the changes in the OpenAPI spec files
- save the diffs in markdown format and upload them to the GitHub workflow artifacts

Note: the PR upgrades the version of the actions used in the workflow



