### PR TITLE
GitHub action: Upload artifacts once

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -79,6 +79,7 @@ jobs:
         done
       # upload generated openapi-diff markdowns as artifacts
     - uses: actions/upload-artifact@v4
+      if: matrix.project == 'java'  # upload artifacts once
       id: artifact-upload-step
       with:
         name: openapi-diff files (commit ${{ env.COMMIT_HASH }})


### PR DESCRIPTION
This PR modifies the workflow to ensure there is only one attempt to upload the OpenAPI diff artifacts.