### PR TITLE
SDK Automation OpenAPI diff: update artifact url

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,7 @@ on:
       - '**/README.md'
       - README.md
       - LICENSE
+      - .github/CODEOWNERS
 
 permissions:
   contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -77,14 +77,22 @@ jobs:
 
           fi
         done
-      # upload generated openapi-diff markdowns as artifacts
+    # upload generated openapi-diff markdowns as artifacts
     - uses: actions/upload-artifact@v4
-      if: matrix.project == 'java'  # upload artifacts once
+      # only for first project (the artifact is always the same)
+      if: matrix.project == 'java' 
       id: artifact-upload-step
       with:
         name: openapi-diff files (commit ${{ env.COMMIT_HASH }})
         path: |
           schema/oas_diff_*.md
+
+    - name: Save artifact URL
+      env:
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+      run: echo "ARTIFACT_URL=https://github.com/$REPO/actions/runs/$RUN_ID" >> $GITHUB_ENV 
+      
     - name: Set PR variables
       id: vars
       run: |
@@ -92,7 +100,7 @@ jobs:
         echo pr_title="Update all services" >> "$GITHUB_OUTPUT"
         echo pr_body="OpenAPI spec or templates produced changes on $(date +%d-%m-%Y) \
           by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). \
-          Download [OpenAPI diffs](${{ steps.artifact-upload-step.outputs.artifact-url }}) to view the changes." >> "$GITHUB_OUTPUT"
+          Download [OpenAPI diffs](${{ env.ARTIFACT_URL }}) to view the changes." >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:


### PR DESCRIPTION
The SDK Automation bot creates a PR in each library's repository after generating the code. It also creates the OpenAPI diff summary (as `.MD` file) and uploads it as artifact in the GitHub action run.

This PR updates the url to the artifact that it is included in each PR (the link will now link the GitHub action run where the artifact is available).