### PR TITLE
(WIP) SDK Automation: update Java generation (sync models and services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,19 @@ For Node.js, set the generator version via CLI:
 Shared logic goes into `buildSrc`. Subprojects can extend and customize predefined tasks via extension
 properties (`project.ext`) or reconfiguration (`tasks.named`).
 
-For local testing of some library:
+For local testing you can create a symbolic link to generate the source code inside the library:
 
 ```shell
 rm -rf go/repo && ln -s ~/workspace/adyen-go-api-library go/repo
+
+rm -rf java/repo && ln -s ~/workspace/adyen-java-api-library java/repo
+```
+
+Remove the symbolic link afterwards:
+```shell
+rm go/repo
+
+rm java/repo
 ```
 
 To run unit tests:

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,70 +12,91 @@ project.ext {
 def services = project.ext.services as List<Service>
 def smallServices = project.ext.smallServices as List<Service>
 
-tasks.withType(GenerateTask).configureEach {
-    def serviceId = project.ext.serviceName.toLowerCase()
+// Deployment: generate models/services
+services.each { Service svc ->
+
+    // Generation
+    def serviceName = project.ext.serviceNaming[svc.id] as String
+    def serviceId = serviceName.toLowerCase()
     def modelNamespace = "com.adyen.model.${serviceId}"
 
-    library.set("jersey3")
-    modelPackage.set(modelNamespace.replace('/', '.'))
-    apiPackage.set("com.adyen.service.${serviceId}")
-    apiNameSuffix.set('Api')
-    additionalProperties.putAll([
-            'dateLibrary'    : 'java8',
-            'openApiNullable': 'false',
-    ])
-}
-
-smallServices.each { Service svc ->
     tasks.named("generate${svc.name}", GenerateTask) {
-        configFile.set("$projectDir/config.yaml")
-        apiPackage.set("com.adyen.service")
+        library.set("jersey3")
+        modelPackage.set(modelNamespace.replace('/', '.'))
+        apiPackage.set("com.adyen.service.${serviceId}")
+        apiNameSuffix.set('Api')
         additionalProperties.putAll([
-                'smallServiceName': "${svc.name}Api",
+                'dateLibrary'    : 'java8',
+                'openApiNullable': 'false',
         ])
     }
-}
 
-// Deployment
-services.each { Service svc ->
-    def deploy = tasks.register("deploy$svc.name", Copy) {
+    // Copy models
+    def deployModels = tasks.register("deploy${svc.name}Models", Sync) {
         group 'deploy'
-        description "Copy $svc.name files into the repo."
+        description "Deploy $svc.name models into the repo."
         dependsOn "generate$svc.name"
         outputs.upToDateWhen { false }
 
-        into layout.projectDirectory.dir("repo")
+        from layout.buildDirectory.dir("services/$svc.id/src/main/java/com/adyen/model/${serviceId}")
+        into layout.projectDirectory.dir("repo/src/main/java/com/adyen/model/" + serviceId)
+    }
 
-        // models
-        def modelsPath = "src/main/java/com/adyen/model"
-        def modelSource = "services/$svc.id/${modelsPath}"
-        from(layout.buildDirectory.dir(modelSource)) {
-            include "**/*.java"
-            into modelsPath
-        }
+    // Copy services
+    def deployServices = tasks.register("deploy${svc.name}Services", Sync) {
+        group 'deploy'
+        description "Deploy $svc.name services into the repo."
+        dependsOn "deploy${svc.name}Models"
+        outputs.upToDateWhen { false }
 
-        // serializer
-        def serializerPath = "src/main/java/com/adyen"
-        def serializerSource = "services/$svc.id/${serializerPath}"
-        from(layout.buildDirectory.file("${serializerSource}/JSON.java")) {
-            into "${modelsPath}/${svc.id}"
-        }
+        from layout.buildDirectory.dir("services/$svc.id/src/main/java/com/adyen/service/${serviceId}")
+        into layout.projectDirectory.dir("repo/src/main/java/com/adyen/service/" + serviceId)
+    }
 
-        // service
-        def servicePath = "src/main/java/com/adyen/service"
-        def serviceSource = "services/$svc.id/${servicePath}"
-        from(layout.buildDirectory.dir("${serviceSource}/$svc.id")) {
-            include "*.java"
-            into "${servicePath}/${svc.id}"
-        }
+    // Copy serializers
+    def deploySerializers = tasks.register("deploy${svc.name}Serializers", Copy) {
+        group 'deploy'
+        description "Deploy $svc.name serializers into the repo."
+        dependsOn "deploy${svc.name}Services"
+        outputs.upToDateWhen { false }
 
-        // small service
-        from(layout.buildDirectory.dir(serviceSource)) {
-            include "*Single.java"
-            into servicePath
-            rename { svc.name + "Api.java" }
+        // move serializer (JSON.java ) into model folder
+        def jsonJavaFile = layout.buildDirectory.file("services/$svc.id/src/main/java/com/adyen/service/JSON.java")
+
+        from jsonJavaFile
+        into layout.buildDirectory.file("services/$svc.id/src/main/java/com/adyen/model/${serviceId}")
+
+        doLast {
+            if (jsonJavaFile.get().asFile.exists()) {
+                delete(jsonJavaFile)
+            } else {
+                println(jsonJavaFile)
+                println("Source file ${jsonJavaFile} not found for deletion.")
+            }
         }
     }
 
-    tasks.named(svc.id) { dependsOn deploy }
+    tasks.named(svc.id) { dependsOn deployModels, deployServices, deploySerializers }
 }
+
+// Tests
+tasks.named('binlookup') {
+    doLast {
+        assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/binlookup/Amount.java").exists()
+        assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/BinLookupServiceApi.java").exists()
+    }
+}
+tasks.named('checkout') {
+    doLast {
+        assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/checkout/Amount.java").exists()
+        assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/checkout/PaymentsApi.java").exists()
+    }
+}
+tasks.named('acswebhooks') {
+    doLast {
+        assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/acswebhooks/Amount.java").exists()
+        assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/acswebhooks").exists()
+        assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/AcsWebhooksApi.java").exists()
+    }
+}
+

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -10,7 +10,6 @@ project.ext {
 }
 
 def services = project.ext.services as List<Service>
-def smallServices = project.ext.smallServices as List<Service>
 
 // Deployment: generate models/services
 services.each { Service svc ->


### PR DESCRIPTION
The generation of the Java library doesn't remove classes when models are deleted from the OpenAPI specs. 
The .NET generation instead re-generates the entire library and removes models that are no longer found in the spec.

This PR refactor the `java/build.gradle` to override the models and services. The gradle file has been updated to align with the `dotnet/build.gradle`.

Note for reviewers:

- the serializer (`JSON.java)` is copied in the `deploySerializers` task
- `smallServices` generation has been removed (it doesn't look like it is still applicable)