### PR TITLE
Go generation: keep webhook_handler.go

### DIFF
--- a/go/build.gradle
+++ b/go/build.gradle
@@ -90,7 +90,12 @@ services.findAll { it.name.endsWith('Webhooks') }.each { Service svc ->
     tasks.named("generate${svc.name}", GenerateTask) { packageName.set(singular) }
     tasks.named("deploy${svc.name}", Copy) {
         def targetDir = layout.projectDirectory.dir("repo/src/${singular}")
-        delete targetDir // Drop content first
+        // Drop content first (except webhook_handler.go)
+        targetDir.asFile.listFiles().each { file ->
+            if (file.name != 'webhook_handler.go') {
+                file.delete()
+            }
+        }
         into targetDir // Copy models
     }
 }


### PR DESCRIPTION
In PR #34 the webhook models are dropped then copied again, after the generation from the latest OpenAPI spec file. However in the same folder there is a file we maintain manually (`webhook_handler.go`) that cannot be removed.

This PR makes sure this file is not deleted during the step above.