### PR TITLE
SDK Automation Bot workflow: Remove OpenAPI diff 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,66 +42,13 @@ jobs:
       run: cp ${{ matrix.project }}/gradle.properties buildSrc
     - name: Generate code for ${{ matrix.project }}
       run: ./gradlew ${{ matrix.project }}:services
-    - name: OpenAPI diffs
-      id: openapi-diffs
-      run: |
-        cd schema
-        COMMIT_HASH=$(git rev-parse HEAD)
-        COMMIT_HASH_BEFORE=$(git rev-parse HEAD^)
-
-        echo "Generate OpenAPI diff between commits [$COMMIT_HASH_BEFORE, $COMMIT_HASH]"            
-
-        # save commit that has triggered the OpenAPI generation
-        echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
-
-        # Fetch files modified by the commit
-        files=$(git diff-tree --no-commit-id --name-only -r $COMMIT_HASH)
-
-        for file in $files; do
-          if [[ $file == *.json ]]; then
-            # get filename
-            filename="${file%.*}"
-            # checkout file before the commit
-            temp_before_name="${filename}_before.json"
-            git show $COMMIT_HASH_BEFORE:$file > $temp_before_name
-        
-            # checkout file after the commit
-            temp_after_name="${filename}_after.json"
-            git show $COMMIT_HASH:$file > $temp_after_name
-
-            docker run -v "$(pwd):/specs" --rm -t tufin/oasdiff:v1.10.27 diff \
-              -f markup \
-              /specs/$temp_before_name \
-              /specs/$temp_after_name \
-              >> "oas_diff_${filename//\//_}.md"
-            echo "$filename ✅"            
-
-          fi
-        done
-    # upload generated openapi-diff markdowns as artifacts
-    - uses: actions/upload-artifact@v4
-      # only for first project (the artifact is always the same)
-      if: matrix.project == 'java' 
-      id: artifact-upload-step
-      with:
-        name: openapi-diff files (commit ${{ env.COMMIT_HASH }})
-        path: |
-          schema/oas_diff_*.md
-
-    - name: Save artifact URL
-      env:
-        REPO: ${{ github.repository }}
-        RUN_ID: ${{ github.run_id }}
-      run: echo "ARTIFACT_URL=https://github.com/$REPO/actions/runs/$RUN_ID" >> $GITHUB_ENV 
-      
     - name: Set PR variables
       id: vars
       run: |
         cd schema
         echo pr_title="Code generation: update services and models" >> "$GITHUB_OUTPUT"
         echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) \
-          by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). \
-          Download [OpenAPI diffs](${{ env.ARTIFACT_URL }}) to view the changes." >> "$GITHUB_OUTPUT"
+          by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:


### PR DESCRIPTION
The OASDiff causes the SDK Automation Bot to fails: this PR removes the execution of `OAS Diff` while we investigate the problem.