### PR TITLE
Revert "Add BalancePlatformBalanceWebhooks to automation-conventions"

### DIFF
--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -43,8 +43,8 @@ List<Service> services = [
         new Service(name: 'TransactionWebhooks', spec: 'BalancePlatformTransactionNotification', version: 4),
         new Service(name: 'ManagementWebhooks', spec: 'ManagementNotificationService', version: 3),
         new Service(name: 'DisputeWebhooks', spec: 'BalancePlatformDisputeNotification', version: 1),
-        new Service(name: 'NegativeBalanceWarningWebhooks', spec: 'BalancePlatformNegativeBalanceCompensationWarningNotification', version: 1),
-        new Service(name: 'BalancePlatformBalanceWebhooks', spec: 'BalancePlatformBalanceNotification', version: 1)
+        new Service(name: 'NegativeBalanceWarningWebhooks', spec: 'BalancePlatformNegativeBalanceCompensationWarningNotification', version: 1)
+
 ]
 
 ext {


### PR DESCRIPTION
Reverts Adyen/adyen-sdk-automation#43

Reverted due incorrect generation of the `allOf`-classes 
![image](https://github.com/user-attachments/assets/8ca7f226-9090-467b-a268-e4d2c2447bdb)
 