### PR TITLE
Remove PosTerminalManagement service

### DIFF
--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -20,8 +20,6 @@ List<Service> services = [
         new Service(name: 'BinLookup', version: 54, small: true),
         new Service(name: 'PosMobile', spec: 'SessionService', version: 68, small: true), 
         new Service(name: 'PaymentsApp', spec: 'PaymentsAppService', version: 1, small: true),
-        // Point of Sale
-        new Service(name: 'PosTerminalManagement', spec: 'TfmAPIService', version: 1, small: true),
         // Management
         new Service(name: 'Management', version: 3),
         new Service(name: 'BalanceControl', version: 1, small: true),


### PR DESCRIPTION
[POS Terminal Management API](https://docs.adyen.com/point-of-sale/automating-terminal-management/assign-terminals-api/) has been deprecated, in favour of the Management API. It has now reached end-of-live and it should no longer be included in the SDK Automation pipeline.