### PR TITLE
Use ADYEN_AUTOMATION_BOT_TEST_EMAIL in workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,8 +54,8 @@ jobs:
       with:
         path: ${{ matrix.project }}/repo
         token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
-        committer: ${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}
-        author: ${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}
+        committer: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
+        author: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
         branch: sdk-automation/models
         title: ${{ steps.vars.outputs.pr_title }}
         body: ${{ steps.vars.outputs.pr_body }}


### PR DESCRIPTION
Injecting `ADYEN_AUTOMATION_BOT_TEST_EMAIL` in the workflow to avoid publishing private email address