### PR TITLE
Node OpenAPI Generator v7

### DIFF
--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -14,7 +14,7 @@ repositories {
 
 // list of services to be generated
 // services are APIs with multiple tags: the generation will create a service class/file for each tag
-// smallServices are APIs with a single tag 'Gene ral': the generation will create a single class/file
+// smallServices are APIs with a single tag 'General': the generation will create a single class/file
 List<Service> services = [
         // Payments
         new Service(name: 'Checkout', version: 71),

--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -14,7 +14,7 @@ repositories {
 
 // list of services to be generated
 // services are APIs with multiple tags: the generation will create a service class/file for each tag
-// smallServices are APIs with a single tag 'General': the generation will create a single class/file
+// smallServices are APIs with a single tag 'Gene ral': the generation will create a single class/file
 List<Service> services = [
         // Payments
         new Service(name: 'Checkout', version: 71),
@@ -211,9 +211,14 @@ project.ext.services.each { Service svc ->
                     if (properties?.containsKey("environment") && properties?.containsKey("data")) {
                         schema.value["x-webhook-root"] = true
                     }
-                    // add 'x-webhook-root' to RelayedAuthenticationRequest model
+                    // add 'x-webhook-root' to RelayedAuthenticationRequest model (missing 'environment' and 'data' attributes)
                     // bespoke fix as the model doesn't adopt the standard schema
                     if (schema.key.equals("RelayedAuthenticationRequest")) {
+                        schema.value["x-webhook-root"] = true
+                    }
+                    // add 'x-webhook-root' to DisputeNotificationRequest model
+                    // bespoke fix as the model doesn't adopt the standard schema (missing 'environment' attribute)
+                    if (schema.key.equals("DisputeNotificationRequest")) {
                         schema.value["x-webhook-root"] = true
                     }
                 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -127,6 +127,7 @@ tasks.named('binlookup') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/binlookup/Amount.java").exists()
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/BinLookupApi.java").exists()
+        // verify DefaultApi class no longer exists (it has been renamed to BinLookupApi)
         assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/binlookup/DefaultApi.java").exists()
     }
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -141,8 +141,11 @@ tasks.named('checkout') {
 tasks.named('acswebhooks') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/acswebhooks/Amount.java").exists()
+        // verify no service package is created for a webhook
         assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/acswebhooks").exists()
+        // verify no API class is created for a webhook
         assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/AcsWebhooksApi.java").exists()
+        // verify Webhook Handler is created
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/acswebhooks/AcsWebhooksHandler.java").exists()
     }
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -122,7 +122,7 @@ services.each { Service svc ->
     tasks.named(svc.id) { dependsOn deployModels, deployServices, deploySerializers, deployWebhookHandlers }
 }
 
-// Test small services generation
+// Test binlookup  generation
 tasks.named('binlookup') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/binlookup/Amount.java").exists()
@@ -130,14 +130,14 @@ tasks.named('binlookup') {
         assert !file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/binlookup/DefaultApi.java").exists()
     }
 }
-// Test services generation
+// Test checkout generation
 tasks.named('checkout') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/checkout/Amount.java").exists()
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/checkout/PaymentsApi.java").exists()
     }
 }
-// Test webhooks generation
+// Test acswebhooks generation
 tasks.named('acswebhooks') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/main/java/com/adyen/model/acswebhooks/Amount.java").exists()

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -46,7 +46,7 @@ services.each { Service svc ->
 
     /**
      * Copy models task
-     * - copy generated models from build (generated code) to the library typings folder
+     * - copy generated models from build (generated code) to the library `/src/typings` folder
      * - rename to start with lowercase (to follow naming conventions)
      * - rename specific files:
      *      - all.ts must be renamed to models.ts
@@ -70,9 +70,10 @@ services.each { Service svc ->
             // Rename specific files
             rename { fileName ->
                 if (fileName == "all.ts") {
+                    // renaming to preserve backward compatibility with previous versions of the Node library
                     return "models.ts"
                 } else if (fileName == "webhookHandler.ts") {
-                    // rename to specific handler (i.e. reportWebhooksHandler.ts)
+                    // rename to create specific handler (i.e. reportWebhooksHandler.ts)
                     def handlerName = "${svc.name}Handler.ts"
                     return handlerName[0].toLowerCase() + handlerName.substring(1)
                 }
@@ -155,9 +156,9 @@ tasks.named('acswebhooks') {
         assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/acsWebhooksHandler.ts").exists()
         // verify objectSerializer is created
         assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/objectSerializer.ts").exists()
-        // verify no service package is created for a webhook
+        // verify no service package is created for a webhook (Webhooks generation must only creates models)
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooks").exists()
-        // verify no API class is created for a webhook
+        // verify no API class is created for a webhook (Webhooks generation must only creates models)
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooksApi.ts").exists()
     }
 }

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -90,13 +90,14 @@ services.each { Service svc ->
      * - copy generated models from build (generated code) to the library services folder
      * - rename to start with lowercase (to follow naming conventions)
      *
+     * Note: webhook specs (i.e. ConfigurationWebhooks, etc.. ) are skipped because Webhooks generation must only creates models
     */
     def deployServices = tasks.register("deploy${svc.name}Services", Sync) {
         group 'deploy'
         description "Deploy $svc.name into the repo."
         dependsOn "generate$svc.name"
         outputs.upToDateWhen { false }
-        onlyIf { !svc.webhook }
+        onlyIf { !svc.webhook } // skip webhooks (this task is for generating service classes only)
 
         from(layout.buildDirectory.dir("services/$svc.id/apis")) {
             include '*Api.ts'

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -2,13 +2,11 @@ plugins {
     id 'adyen.sdk-automation-conventions'
 }
 
-
 import com.adyen.sdk.Service
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 project.ext {
-    generator = 'typescript-node'
-    templates = 'templates/typescript'
+    generator = 'typescript'
 }
 
 def services = project.ext.services as List<Service>
@@ -17,38 +15,81 @@ def services = project.ext.services as List<Service>
 Map<String, String> serviceNaming = project.ext.serviceNamingCamel
 
 services.each { Service svc ->
+    // service name starting lowercase
     String serviceName = serviceNaming[svc.id]
+    // service unmodified (starting with uppercase)
+    String originalServiceName = svc.name
 
     // Generation
     tasks.named("generate${svc.name}", GenerateTask) {
-        apiPackage.set(serviceName)
-        configFile.set("$projectDir/config.yaml")
+        templateDir.set("$projectDir/repo/templates-v7/typescript")
+
+        apiNameSuffix.set('Api')
         additionalProperties.putAll([
-                'modelPropertyNaming': 'original',
-                'serviceName'        : serviceName,
+                'modelPropertyNaming'  : 'original',
+                'serviceName'          : serviceName,
+                'originalServiceName'  : originalServiceName,
+                'enumPropertyNaming'   : 'PascalCase',
         ])
+
+        // for webhooks apply extra config.yaml (to generate WebhookHandler)
+        if (serviceId.endsWith("webhooks")) {
+            configFile.set("$projectDir/config.yaml")
+        }
     }
 
-    // Deployment
+    // Copy models
     def deployModels = tasks.register("deploy${svc.name}Models", Sync) {
         group 'deploy'
         description "Deploy $svc.name models into the repo."
         dependsOn "generate$svc.name"
         outputs.upToDateWhen { false }
 
-        from layout.buildDirectory.dir("services/$svc.id/model")
+        from(layout.buildDirectory.dir("services/$svc.id/models")) {
+            eachFile { fileCopyDetails ->
+                def name = fileCopyDetails.name
+                if (name && name.length() > 0) {
+                    // copy and rename to start with lowercase
+                    fileCopyDetails.name = name[0].toLowerCase() + name.substring(1)
+                }
+            }
+
+            // Rename specific files
+            rename { fileName ->
+                if (fileName == "all.ts") {
+                    return "models.ts"
+                } else if (fileName == "webhookHandler.ts") {
+                    // rename to specific handler (i.e. reportWebhooksHandler.ts)
+                    def handlerName = "${svc.name}Handler.ts"
+                    return handlerName[0].toLowerCase() + handlerName.substring(1)
+                }
+                return fileName
+            }
+
+            includeEmptyDirs = false
+        }
         into layout.projectDirectory.dir("repo/src/typings/" + serviceName)
     }
 
+    // copy services
     def deployServices = tasks.register("deploy${svc.name}Services", Sync) {
         group 'deploy'
         description "Deploy $svc.name into the repo."
         dependsOn "generate$svc.name"
         outputs.upToDateWhen { false }
-        onlyIf { !svc.small && !svc.webhook }
+        onlyIf { !svc.webhook }
 
-        from layout.buildDirectory.dir("services/$svc.id/${serviceName}")
-        include '*Api.ts'
+        from(layout.buildDirectory.dir("services/$svc.id/apis")) {
+            include '*Api.ts'
+            eachFile { fileCopyDetails ->
+                def name = fileCopyDetails.name
+                if (name && name.length() > 0) {
+                    // copy and rename to start with lowercase
+                    fileCopyDetails.name = name[0].toLowerCase() + name.substring(1)
+                }
+            }
+            includeEmptyDirs = false
+        }
         into layout.projectDirectory.dir("repo/src/services/" + serviceName)
 
         from(layout.buildDirectory.dir("services/$svc.id")) {
@@ -56,19 +97,7 @@ services.each { Service svc ->
         }
     }
 
-    def deploySmallService = tasks.register("deploy${svc.name}SmallService", Copy) {
-        group 'deploy'
-        description "Copy $svc.name into the repo."
-        dependsOn "generate$svc.name"
-        outputs.upToDateWhen { false }
-        onlyIf { svc.small }
-
-        from layout.buildDirectory.file("services/$svc.id/${serviceName}/defaultApiRoot.ts")
-        rename 'defaultApiRoot.ts', "${serviceName}Api.ts"
-        into layout.projectDirectory.dir('repo/src/services')
-    }
-
-    tasks.named(svc.id) { dependsOn deployModels, deployServices, deploySmallService }
+    tasks.named(svc.id) { dependsOn deployModels, deployServices }
 }
 
 // Tests
@@ -80,6 +109,8 @@ tasks.named('binlookup') {
 }
 tasks.named('checkout') {
     doLast {
+        assert file("${layout.projectDirectory}/repo/src/typings/checkout/models.ts").exists()
+        assert file("${layout.projectDirectory}/repo/src/typings/checkout/objectSerializer.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/typings/checkout/amount.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/services/checkout/paymentsApi.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/services/checkout/index.ts").exists()
@@ -87,14 +118,17 @@ tasks.named('checkout') {
 }
 tasks.named('balanceplatform') {
     doLast {
+        assert file("${layout.projectDirectory}/repo/src/typings/balancePlatform/models.ts").exists()
+        assert file("${layout.projectDirectory}/repo/src/typings/balancePlatform/objectSerializer.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/typings/balancePlatform/amount.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/services/balancePlatform/accountHoldersApi.ts").exists()
-        assert !file("${layout.projectDirectory}/repo/src/services/balanceplatform/accountHoldersApi.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/services/balancePlatform/index.ts").exists()
     }
 }
 tasks.named('acswebhooks') {
     doLast {
+        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/acsWebhooksHandler.ts").exists()
+        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/objectSerializer.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/amount.ts").exists()
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooks").exists()
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooksApi.ts").exists()

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -1,3 +1,9 @@
+/**
+ * This Gradle build script is designed to automate the generation of the TypeScript code from the OpenAPI specifications,
+ * It orchestrates the entire process, from code generation to copying the generated files in the correct source directories
+ * (services, typings).
+ * It includes verification steps to confirm the outcome of the generation.
+ */
 plugins {
     id 'adyen.sdk-automation-conventions'
 }
@@ -38,7 +44,14 @@ services.each { Service svc ->
         }
     }
 
-    // Copy models
+    /**
+     * Copy models task
+     * - copy generated models from build (generated code) to the library typings folder
+     * - rename to start with lowercase (to follow naming conventions)
+     * - rename specific files:
+     *      - all.ts must be renamed to models.ts
+     *      - webhookHandler.ts must be renamed to specific handler (i.e. reportWebhooksHandler.ts)
+     */
     def deployModels = tasks.register("deploy${svc.name}Models", Sync) {
         group 'deploy'
         description "Deploy $svc.name models into the repo."
@@ -71,7 +84,13 @@ services.each { Service svc ->
         into layout.projectDirectory.dir("repo/src/typings/" + serviceName)
     }
 
-    // copy services
+
+    /**
+     * Copy services task
+     * - copy generated models from build (generated code) to the library services folder
+     * - rename to start with lowercase (to follow naming conventions)
+     *
+    */
     def deployServices = tasks.register("deploy${svc.name}Services", Sync) {
         group 'deploy'
         description "Deploy $svc.name into the repo."
@@ -91,7 +110,7 @@ services.each { Service svc ->
             includeEmptyDirs = false
         }
         into layout.projectDirectory.dir("repo/src/services/" + serviceName)
-
+        // copy index.ts (export service classes)
         from(layout.buildDirectory.dir("services/$svc.id")) {
             include 'index.ts'
         }
@@ -100,13 +119,14 @@ services.each { Service svc ->
     tasks.named(svc.id) { dependsOn deployModels, deployServices }
 }
 
-// Tests
+// Test binlookup
 tasks.named('binlookup') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/typings/binLookup/amount.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/services/binLookupApi.ts").exists()
     }
 }
+// Test checkout
 tasks.named('checkout') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/typings/checkout/models.ts").exists()
@@ -116,6 +136,7 @@ tasks.named('checkout') {
         assert file("${layout.projectDirectory}/repo/src/services/checkout/index.ts").exists()
     }
 }
+// Test balanceplatform
 tasks.named('balanceplatform') {
     doLast {
         assert file("${layout.projectDirectory}/repo/src/typings/balancePlatform/models.ts").exists()
@@ -125,12 +146,17 @@ tasks.named('balanceplatform') {
         assert file("${layout.projectDirectory}/repo/src/services/balancePlatform/index.ts").exists()
     }
 }
+// Test acswebhooks
 tasks.named('acswebhooks') {
     doLast {
-        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/acsWebhooksHandler.ts").exists()
-        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/objectSerializer.ts").exists()
         assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/amount.ts").exists()
+        // verify Webhook Handler is created
+        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/acsWebhooksHandler.ts").exists()
+        // verify objectSerializer is created
+        assert file("${layout.projectDirectory}/repo/src/typings/acsWebhooks/objectSerializer.ts").exists()
+        // verify no service package is created for a webhook
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooks").exists()
+        // verify no API class is created for a webhook
         assert !file("${layout.projectDirectory}/repo/src/services/acsWebhooksApi.ts").exists()
     }
 }

--- a/node/config.yaml
+++ b/node/config.yaml
@@ -1,10 +1,5 @@
 files:
-  api-index.mustache:
-    destinationFilename: index.ts
+  model/webhook_handler.mustache:
+    folder: models
+    destinationFilename: WebhookHandler.ts
     templateType: SupportingFiles
-  api-single.mustache:
-    destinationFilename: .ts
-    templateType: API
-  api-root.mustache:
-    destinationFilename: Root.ts
-    templateType: API

--- a/node/gradle.properties
+++ b/node/gradle.properties
@@ -1,1 +1,1 @@
-openapiGeneratorVersion=5.4.0
+openapiGeneratorVersion=7.13.0


### PR DESCRIPTION
Update SDK Automation Bot to use Node OpenAPI Generator v7:

- upgrade OpenAPI Generator version
- configure to use Node generator v7 templates
- automate generation of Webhook events (including custom fix for DisputeWebhooks)