### PR TITLE
PHP Split Code Generation POC

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -115,7 +115,7 @@ jobs:
           token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
           committer: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
           author: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
-          branch: sdk-automation/models
+          branch: sdk-automation/${{ matrix.tag }}
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           commit-message: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,10 +17,11 @@ concurrency:
   group: ci-sdk-automation
 
 jobs:
+  # generate code for the libraries defined in the matrix
   generate:
     strategy:
       matrix:
-        project: [ go, php, java, node, dotnet, python, ruby ]
+        project: [ go, java, node, dotnet, python, ruby ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -61,3 +62,61 @@ jobs:
         body: ${{ steps.vars.outputs.pr_body }}
         commit-message: |
           ${{ contains(fromJSON('["go", "php", "node"]'), matrix.project) && '[reformat]' }}[adyen-sdk-automation] automated change
+  # setup PHP library
+  setupPhp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone PHP repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+          repository: Adyen/adyen-php-api-library
+          path: php/repo
+
+      - name: Set workspace output
+        id: set-output
+        run: echo "workspace=$GITHUB_WORKSPACE" >> $GITHUB_OUTPUT
+  # generate PHP library
+  generatePhp:
+    needs: setupPhp
+    runs-on: ubuntu-latest
+    # generate code as defined in the matrix
+    # each iteration generates a group of services and creates a PR
+    strategy:
+      matrix:
+        tag: [PaymentsAPIs, ManagementAPIs, PlatformsAPIs, Webhooks]
+
+    steps:
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Generate code for PHP ${{ matrix.tag }}
+        run: ./gradlew php:${{ matrix.tag }}
+
+      - name: Set PR variables
+        id: vars
+        run: |
+          cd schema
+          echo pr_title="[${{ matrix.tag }}] Code generation: update services and models" >> "$GITHUB_OUTPUT"
+          echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) \
+            by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: php/repo
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+          committer: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
+          author: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
+          branch: sdk-automation/models
+          title: ${{ steps.vars.outputs.pr_title }}
+          body: ${{ steps.vars.outputs.pr_body }}
+          commit-message: |
+            ${{ contains(fromJSON('["go", "php", "node"]'), 'php') && '[reformat]' }}[adyen-sdk-automation] automated change

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -119,4 +119,5 @@ jobs:
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           commit-message: |
-            ${{ contains(fromJSON('["go", "php", "node"]'), 'php') && '[reformat]' }}[adyen-sdk-automation] automated change
+            # include [reformat] for PHP
+            [reformat][adyen-sdk-automation] automated changes

--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -17,37 +17,36 @@ repositories {
 // smallServices are APIs with a single tag 'General': the generation will create a single class/file
 List<Service> services = [
         // Payments
-        new Service(name: 'Checkout', version: 71),
-        new Service(name: 'Payout', version: 68),
-        new Service(name: 'Recurring', version: 68, small: true),
-        new Service(name: 'BinLookup', version: 54, small: true),
-        new Service(name: 'PosMobile', spec: 'SessionService', version: 68, small: true), 
-        new Service(name: 'PaymentsApp', spec: 'PaymentsAppService', version: 1, small: true),
-        // Management
-        new Service(name: 'Management', version: 3),
-        new Service(name: 'BalanceControl', version: 1, small: true),
-        // Adyen for Platforms
-        new Service(name: 'LegalEntityManagement', spec: 'LegalEntityService', version: 3),
-        new Service(name: 'BalancePlatform', version: 2),
-        new Service(name: 'Transfers', spec: 'TransferService', version: 4),
-        new Service(name: 'DataProtection', version: 1, small: true),
-        new Service(name: 'SessionAuthentication', version: 1),
+        new Service(name: 'Checkout', version: 71, tag: 'Payments'),
+        new Service(name: 'Payout', version: 68, tag: 'Payments'),
+        new Service(name: 'Recurring', version: 68, small: true, tag: 'Payments'),
+        new Service(name: 'BinLookup', version: 54, small: true, tag: 'Payments'),
+        new Service(name: 'PosMobile', spec: 'SessionService', version: 68, small: true, tag: 'Payments'),
+        new Service(name: 'PaymentsApp', spec: 'PaymentsAppService', version: 1, small: true, tag: 'Payments'),
+        new Service(name: 'Disputes', spec: 'DisputeService', version: 30, small: true, tag: 'Payments'),
+        new Service(name: 'StoredValue', version: 46, small: true, tag: 'Payments'),
         // Classic Payments
-        new Service(name: 'Payment', version: 68, small: true),
-        // Others
-        new Service(name: 'StoredValue', version: 46, small: true),
-        new Service(name: 'Disputes', spec: 'DisputeService', version: 30, small: true),
+        new Service(name: 'Payment', version: 68, small: true, tag: 'Payments'),
+        // Management
+        new Service(name: 'Management', version: 3, tag: 'Management'),
+        new Service(name: 'BalanceControl', version: 1, small: true, tag: 'Management'),
+        // Adyen for Platforms
+        new Service(name: 'LegalEntityManagement', spec: 'LegalEntityService', version: 3, tag: 'Platforms'),
+        new Service(name: 'BalancePlatform', version: 2, tag: 'Platforms'),
+        new Service(name: 'Transfers', spec: 'TransferService', version: 4, tag: 'Platforms'),
+        new Service(name: 'DataProtection', version: 1, small: true, tag: 'Platforms'),
+        new Service(name: 'SessionAuthentication', version: 1, tag: 'Platforms'),
         // Webhooks
-        new Service(name: 'ConfigurationWebhooks', spec: 'BalancePlatformConfigurationNotification', version: 2),
-        new Service(name: 'AcsWebhooks', spec: 'BalancePlatformAcsNotification', version: 1),
-        new Service(name: 'ReportWebhooks', spec: 'BalancePlatformReportNotification', version: 1),
-        new Service(name: 'TransferWebhooks', spec: 'BalancePlatformTransferNotification', version: 4),
-        new Service(name: 'TransactionWebhooks', spec: 'BalancePlatformTransactionNotification', version: 4),
-        new Service(name: 'ManagementWebhooks', spec: 'ManagementNotificationService', version: 3),
-        new Service(name: 'DisputeWebhooks', spec: 'BalancePlatformDisputeNotification', version: 1),
-        new Service(name: 'NegativeBalanceWarningWebhooks', spec: 'BalancePlatformNegativeBalanceCompensationWarningNotification', version: 1),
-        new Service(name: 'BalanceWebhooks', spec: 'BalancePlatformBalanceNotification', version: 1),
-        new Service(name: 'TokenizationWebhooks', spec: 'TokenizationNotification', version: 1)
+        new Service(name: 'ConfigurationWebhooks', spec: 'BalancePlatformConfigurationNotification', version: 2, tag: 'Webhooks'),
+        new Service(name: 'AcsWebhooks', spec: 'BalancePlatformAcsNotification', version: 1, tag: 'Webhooks'),
+        new Service(name: 'ReportWebhooks', spec: 'BalancePlatformReportNotification', version: 1, tag: 'Webhooks'),
+        new Service(name: 'TransferWebhooks', spec: 'BalancePlatformTransferNotification', version: 4, tag: 'Webhooks'),
+        new Service(name: 'TransactionWebhooks', spec: 'BalancePlatformTransactionNotification', version: 4, tag: 'Webhooks'),
+        new Service(name: 'ManagementWebhooks', spec: 'ManagementNotificationService', version: 3, tag: 'Webhooks'),
+        new Service(name: 'DisputeWebhooks', spec: 'BalancePlatformDisputeNotification', version: 1, tag: 'Webhooks'),
+        new Service(name: 'NegativeBalanceWarningWebhooks', spec: 'BalancePlatformNegativeBalanceCompensationWarningNotification', version: 1, tag: 'Webhooks'),
+        new Service(name: 'BalanceWebhooks', spec: 'BalancePlatformBalanceNotification', version: 1, tag: 'Webhooks'),
+        new Service(name: 'TokenizationWebhooks', spec: 'TokenizationNotification', version: 1, tag: 'Webhooks')
 ]
 
 ext {
@@ -57,6 +56,7 @@ ext {
     removeTags = true
     setProperty('services', services)
     smallServices = services.findAll { it.small }
+
     serviceNaming = services.collectEntries { [it.id, it.name] }
     serviceNamingCamel = services.collectEntries {
         [it.id, it.name.substring(0, 1).toLowerCase() + it.name.substring(1)]
@@ -105,9 +105,34 @@ services.each { Service svc ->
     }
 }
 
+// generate all services
 tasks.register('services') {
     description 'Generate code for multiple services.'
     dependsOn services.collect { it.id }
+}
+
+// generate services with tag 'Payments'
+tasks.register('paymentsApis') {
+    description 'Generate code for Payments services.'
+    dependsOn services.findAll { it.tag == 'Payments' }.collect { it.id }
+}
+
+// generate services with tag 'Management'
+tasks.register('managementApis') {
+    description 'Generate code for Management services.'
+    dependsOn services.findAll { it.tag == 'Management' }.collect { it.id }
+}
+
+// generate services with tag 'Platforms'
+tasks.register('platformsApis') {
+    description 'Generate code for Platforms services.'
+    dependsOn services.findAll { it.tag == 'Platforms' }.collect { it.id }
+}
+
+// generate services with tag 'Webhooks'
+tasks.register('webhooks') {
+    description 'Generate code for Webhooks.'
+    dependsOn services.findAll { it.tag == 'Webhooks' }.collect { it.id }
 }
 
 tasks.named('generateCheckout', GenerateTask) {

--- a/buildSrc/src/main/groovy/com/adyen/sdk/Service.groovy
+++ b/buildSrc/src/main/groovy/com/adyen/sdk/Service.groovy
@@ -1,7 +1,7 @@
 package com.adyen.sdk
 
 class Service {
-    String name, spec
+    String name, spec, tag
     int version
     boolean small
 
@@ -12,4 +12,5 @@ class Service {
     String getFilename() { "${getSpec()}-v${version}.json" }
 
     boolean isWebhook() { name.endsWith('Webhooks') }
+
 }


### PR DESCRIPTION
Update SDK Automation GitHub action to skip PHP during the code generation, then add a new section to the workflow to generate separately the PHP library source code:

- generate the code by different modules: Payments, Management, Platforms, Webhooks
- create a PR with the changes for each module

This is a POC to explore if a more granular generation can improve the code generation: smaller PRs, better Release Notes, review and merge modules (i.e. Payments) indipendently

