### PR TITLE
PHP Generation: create PR when there are changes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -100,7 +100,20 @@ jobs:
           echo pr_title="[${{ matrix.tag }}] Code generation: update services and models" >> "$GITHUB_OUTPUT"
           echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) \
             by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          cd php/repo
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # create PR is there are changes    
       - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           path: php/repo


### PR DESCRIPTION
The PHP generation creates 4 PRs: Payments, Management, Platforms, Webhooks.
When only a spec is updated (i.e. Checkout) 3 PRs are created with no changes.

This is an update to the workflow that checks if there are changes, before creating a PR in the PHP library repo.