### PR TITLE
Java: add post-process function

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -51,10 +51,8 @@ services.each { Service svc ->
             ]
 
             replaceFromTo.each { from, to ->
-                if (text.contains(from)) {
-                    //println "Replacing ${from} → ${to} in ${file.name}"
-                    text = text.replace(from, to)
-                }
+                //println "Replacing ${from} → ${to} in ${file.name}"
+                text = text.replace(from, to)
             }
             file.text = text
         }


### PR DESCRIPTION
During the code generation the naming conventions are violated when the parameter/attribute begins with an acronym, for example during the generation of `ScaAssociationManagementApi` the header `WWW-Authenticate` is converted into `wwWAuthenticate` parameter.

This PR introduces a post-generation function `replaceReservedWords` that renames words accordingly.

Advantages: enforce naming conventions when we cannot control the code generation 
Disadvantages: every library might have different words/conventions, therefore we cannot centralise this logic IMO

@galesky-a What do you think? The same solution is applied in the (new) .NET generation.
