### PR TITLE
Java BalancePlatform generation: correct test

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -184,7 +184,7 @@ tasks.named('balanceplatform') {
     doLast {
         // HTTP header not found in signature
         def fileContent = file("${layout.projectDirectory}/repo/src/main/java/com/adyen/service/balanceplatform/ScaAssociationManagementApi.java").text
-        assert !fileContent.contains("wwwAuthenticate")
+        assert !fileContent.contains("wwwAuthenticate"), "'wwwAuthenticate' (HTTP header) should not be part of a method signature in ScaAssociationManagementApi.java"
     }
 }
 


### PR DESCRIPTION
Fix incorrect test that wasn't updated after refactoring the method signature generation (must not include HTTP headers)