### PR TITLE
Add handleNullableProperties flag for API models

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -28,13 +28,11 @@ tasks.withType(GenerateTask).configureEach {
             "containerDefaultToNull" : "true"
     ])
 
-    // for webhooks only apply extra config.yaml (to generate WebhookHandler)
     if (serviceId.endsWith("webhooks")) {
+        // for webhooks only apply extra config.yaml (to generate WebhookHandler)
         configFile.set("$projectDir/config.yaml")
-    }
-
-    // for APIs only add custom code to handle nullable properties
-    if (!serviceId.endsWith("webhooks")) {
+    } else {
+        // for APIs only add custom code to handle nullable properties
         additionalProperties.handleNullableProperties = true
     }
 


### PR DESCRIPTION
This PR add the `handleNullableProperties` additionalData when processing API specs (not webhooks). The flag is used during the Java code generation to generate the code for handling nullable properties, ensuring the Webhook classes don't include this code (as it is not applicable).