### PR TITLE
feat(ci): format java code during generation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -183,6 +183,11 @@ jobs:
           SERVICE: ${{ matrix.service }}
         run: ./gradlew $PROJECT:$SERVICE
 
+      - name: Format Java code
+        if: matrix.project == 'java'
+        working-directory: ${{ matrix.project }}/repo
+        run: mvn spotless:apply
+
       - name: Check for changes
         id: changes
         env:


### PR DESCRIPTION
Adds a formatting step to the Java code generation workflow.

This runs 'mvn spotless:apply' after code generation to ensure that generated code is formatted correctly before a pull request is created. This prevents creating pull requests that only contain formatting changes, which can happen when the code generation output doesn't perfectly match the project's style guidelines.