### PR TITLE
Introduce Capital API to Python lib

### DIFF
--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -49,6 +49,14 @@ List<Service> services = [
         new Service(name: 'TokenizationWebhooks', spec: 'TokenizationNotification', version: 1, tag: 'Webhooks')
 ]
 
+// For now, introduce Capital only for Python.
+// Services is a static list consumed at Gradle configuration time for service-specific task generation:
+//   e.g., X -> generateXService,  deployX{Models, Services}
+// Thus, lib-specific generation must be handled at convention-plugin level (instead of subproject level)
+if (project.name == "python") {
+    services.add(new Service(name: 'Capital', version: 1, tag: "Platforms"))
+}
+
 ext {
     generator = project.name
     templates = 'templates'
@@ -215,12 +223,13 @@ project.ext.smallServices.each { Service svc ->
     tasks.named("generate$svc.name") { dependsOn ungroup }
 }
 
-import groovy.json.JsonSlurper
-import groovy.json.JsonOutput
-
 // update OpenAPI file of the webhooks to add a custom extension 'x-webhook-root' to the model that represents the webhook payload
 // this is necessary to generate the WebhookHandler that deserialises the Webhook models
 project.ext.services.each { Service svc ->
+    // unnecessary to create webhook-related tasks for services/specs not related to webhooks
+    if (!svc.webhook) {
+        return
+    }
     def addWebhookExtension = tasks.register("addWebhookExtension${svc.name}") {
         group 'specs'
         description "Add x-webhook-root extension to ${svc.name}"
@@ -229,8 +238,7 @@ project.ext.services.each { Service svc ->
             def specFile = file("$rootDir/schema/json/${svc.filename}")
             def json = new JsonSlurper().parse(specFile)
 
-            // Check if the service name ends with "Webhooks"
-            if (svc.name.endsWith("Webhooks") && json.containsKey("components") && json["components"].containsKey("schemas")) {
+            if (json.containsKey("components") && json["components"].containsKey("schemas")) {
                 json["components"]["schemas"].each { Map.Entry schema ->
                     def properties = schema.value?.properties
                     // add 'x-webhook-root' to the webhook model (we find 'environment' and 'data' attributes)

--- a/buildSrc/src/main/groovy/com/adyen/sdk/Service.groovy
+++ b/buildSrc/src/main/groovy/com/adyen/sdk/Service.groovy
@@ -1,16 +1,62 @@
 package com.adyen.sdk
 
+/**
+ * Holds required information for code generation.
+ */
 class Service {
-    String name, spec, tag
+    /**
+     * The target name of the generated service
+     */
+    String name
+
+    /**
+     * The source API spec
+     */
+    String spec
+
+    /**
+     * The version of the source API spec
+     */
     int version
+
+    /**
+     * Name used for grouping services around a common tag
+     */
+    String tag
+
+    /**
+     * A "small" service is a service that is generated in a self-contained file.
+     * In contrast, for some languages, the generated code might be bundled inside a directory.
+     * Note that it's up to the underlying libs to honor this flag.
+     */
+    /*
+      TODO: review where this is actually used because it **feels** lib specific and
+        not generic enough to deserve its place here.
+        Plus, "small" doesn't hint much about its actual meaning.
+     */
     boolean small
 
     String getId() { name.toLowerCase() }
 
-    String getSpec() { spec ?: "${name}Service" }
-
+    /**
+     * The target file associated with this service
+     *
+     * @return The file name associated with this service
+     */
     String getFilename() { "${getSpec()}-v${version}.json" }
 
-    boolean isWebhook() { name.endsWith('Webhooks') }
+    /**
+     * Indicates whether this target is related to a spec from a webhook.
+     *
+     * @return <code>true</code> if this service is a webhook
+     */
+    boolean isWebhook() { name.endsWith("Webhooks") }
 
+    /**
+     * The spec convention name.
+     * If this service has no explicit spec, it defaults to `<name>Service`
+     *
+     * @return The spec convention name
+     */
+    String getSpec() { spec ?: "${name}Service" }
 }

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -56,13 +56,26 @@ services.<Service> each { Service svc ->
         }
     }
 
-    tasks.named(svc.id) { dependsOn deployServices}
+    tasks.named(svc.id) { dependsOn deployServices }
 }
 
-// Tests
-tasks.named('checkout') {
-    doLast {
-        assert file("${layout.projectDirectory}/repo/Adyen/services/checkout/payments_api.py").exists()
-        assert file("${layout.projectDirectory}/repo/Adyen/services/checkout/__init__.py").exists()
+// TODO: Review how to generalize this to other libs
+/**
+ * Configures a service lifecycle tasks to perform a final sanity check: ensure that given files exists at the expected location.
+ * @param serviceName the service to be checked
+ * @param files the expected files
+ */
+def assertServiceFilesExist(String serviceName, List<String> files) {
+    tasks.named(serviceName) {
+        // Hooks into this lifecycle task to do a sanity check: ensure that the given files
+        // exists in the expected location
+        doLast {
+            files.forEach {
+                assert file("${layout.projectDirectory}/repo/Adyen/services/${serviceName}/" + it).exists()
+            }
+        }
     }
 }
+
+assertServiceFilesExist('checkout', ["payments_api.py", "__init__.py"])
+assertServiceFilesExist('capital', ["__init__.py", "grants_api.py", "grant_offers_api.py", "grant_accounts_api.py"])


### PR DESCRIPTION
This PR introduces Capital API for Python lib. In addition, there was some cleanup and documentation done.
There were no required changes to GH workflow. Once this PR merge, we should see at some point some PR triggered for Capital in the Python lib project.

See changes for more details.
