### PR TITLE
fix(ci): Prevent workflow crash by removing line break in PR body

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,8 +53,7 @@ jobs:
       run: |
         cd schema
         echo pr_title="Code generation: update services and models" >> "$GITHUB_OUTPUT"
-        echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) \ 
-          by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
+        echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
@@ -109,8 +108,7 @@ jobs:
         run: |
           cd schema
           echo "pr_title=[$TAG] Code generation: update services and models" >> "$GITHUB_OUTPUT"
-          echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) \ 
-            by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
+          echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
Removes an unnecessary newline from the pull request body in the Gradle workflow, which was causing the workflow to crash.
