### PR TITLE
FIX shared logic for openapi generator version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,11 +39,6 @@ jobs:
         path: ${{ matrix.project }}/repo
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
-    - name: Override properties
-      if: matrix.project == 'node' || matrix.project == 'java' || matrix.project == 'python'  || matrix.project == 'ruby'
-      env:
-        PROJECT: ${{ matrix.project }}
-      run: cp $PROJECT/gradle.properties buildSrc
     - name: Generate code for ${{ matrix.project }}
       env:
         PROJECT: ${{ matrix.project }}
@@ -168,12 +163,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Override properties
-        if: matrix.project == 'node' || matrix.project == 'java'
-        env:
-          PROJECT: ${{ matrix.project }}
-        run: cp $PROJECT/gradle.properties buildSrc
 
       - name: Generate code for ${{ matrix.service }} in ${{ matrix.project }}
         env:

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,6 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation "org.openapitools:openapi-generator-gradle-plugin:${openapiGeneratorVersion}"
+    implementation "org.openapitools:openapi-generator-gradle-plugin:6.0.1"
     testImplementation 'junit:junit:4.13.2'
 }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,1 +1,0 @@
-openapiGeneratorVersion=6.0.1

--- a/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
+++ b/buildSrc/src/main/groovy/adyen.sdk-automation-conventions.gradle
@@ -7,10 +7,6 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
-def props = new Properties()
-rootProject.file("buildSrc/gradle.properties").withInputStream { props.load(it) }
-project.ext.openApiVersion = props.getProperty('openapiGeneratorVersion')
-
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
@@ -62,6 +58,8 @@ if (project.name == "python") {
 }
 
 ext {
+    // applicable to all, can be overridden at project level if needed
+    openapiGeneratorVersion = "6.0.1"
     generator = project.name
     templates = 'templates'
     serviceName = ''
@@ -171,7 +169,7 @@ tasks.register('cloneRepo', Exec) {
 // Disable generator caching
 tasks.withType(GenerateTask).configureEach {
     doFirst {
-        println "Using OpenAPI Generator version ${project.openApiVersion}"
+        println "Using OpenAPI Generator version ${project.ext.openapiGeneratorVersion}"
     }
     outputs.upToDateWhen { false }
     outputs.cacheIf { false }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 project.ext {
-    generator = 'java'
+    openapiGeneratorVersion='7.11.0'
 }
 
 def services = project.ext.services as List<Service>

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,1 +1,0 @@
-openapiGeneratorVersion=7.11.0

--- a/node/build.gradle
+++ b/node/build.gradle
@@ -13,6 +13,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 project.ext {
     generator = 'typescript'
+    openapiGeneratorVersion='7.13.0'
 }
 
 def services = project.ext.services as List<Service>

--- a/node/gradle.properties
+++ b/node/gradle.properties
@@ -1,1 +1,0 @@
-openapiGeneratorVersion=7.13.0

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 project.ext {
-    generator = 'python'
+    openapiGeneratorVersion='7.13.0'
 }
 
 List<Service> services = project.ext.services

--- a/python/gradle.properties
+++ b/python/gradle.properties
@@ -1,1 +1,0 @@
-openapiGeneratorVersion=7.13.0

--- a/ruby/build.gradle
+++ b/ruby/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 project.ext {
-    generator = 'ruby'
+    openapiGeneratorVersion='7.13.0'
 }
 
 List<Service> services = project.ext.services

--- a/ruby/gradle.properties
+++ b/ruby/gradle.properties
@@ -1,1 +1,0 @@
-openapiGeneratorVersion=7.13.0


### PR DESCRIPTION
These changes allow to set (and override) openapi generator version via project extensions. This also eliminates the need to set project-level Gradle properties (which was misbehaving previously).