### PR TITLE
Kick lang formatting using composable workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -231,4 +231,3 @@ jobs:
 
             The commit history of this PR reflects the `adyen-openapi` commits that have been applied.
           commit-message: '[${{ matrix.service }}] Automated update from Adyen/adyen-openapi@${{ steps.vars.outputs.sha_short }}'
-          labels: "automated pr"


### PR DESCRIPTION
## Summary

Running formatting after generation makes calculating diff impossible. This is the current flow:

```
1. Generate
2. If diff, Create PR
3. Format
```

Because (3) happens after (2), the next time generation runs it will compare `formatted` with `raw`, meaning there will always be a delta

This PR fixes this by making sure formatting happens before the diff is calculated.

It's done by invoking a composable action on each lang's repos. I've already [moved](https://github.com/Adyen/adyen-java-api-library/pull/1660) the format action in `java` to this setup and will proceed with the same for the other languages.


## Tested scenarios

* Tested by creating a checkpoint commit that only created one PR on the Java Repo. See the PR [here](https://github.com/Adyen/adyen-java-api-library/pull/1663) and the checkpoint [here](https://github.com/Adyen/adyen-sdk-automation/pull/85/changes/698330bc8b0ac342e220c1d3b35adb248807ca3f).


