### PR TITLE
feat(ci): create one pr per service for python

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
   generate:
     strategy:
       matrix:
-        project: [ dotnet, python, ruby ]
+        project: [ dotnet, ruby ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [ java, php, node ]
+        project: [ java, php, node, python ]
         service: [
           checkout, payout, recurring, binlookup, posmobile, paymentsapp, disputes, storedvalue, payment,
           management, balancecontrol, legalentitymanagement, balanceplatform, transfers, dataprotection,


### PR DESCRIPTION
Enables creating one pr per service for python.

The Python lib doesn't contain a formatter so there is no extra PR.