### PR TITLE
fix(ci): check for untracked files too

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -204,10 +204,13 @@ jobs:
         id: changes
         working-directory: ${{ matrix.project }}/repo
         run: |
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
+          # Check for modified tracked files AND new untracked files
+          if [ -n "$(git status --porcelain)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes detected."
           fi
 
       - name: Get OpenAPI commit SHA


### PR DESCRIPTION
When checking for changes on PRs we were not looking at scenarios where all the files are new.