### PR TITLE
FIX set JVM actions to JDK 21 LTS version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
     - name: Clone ${{ matrix.project }} repository
       uses: actions/checkout@v6
@@ -89,10 +89,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: ${{ matrix.project }} generate code for ${{ matrix.tag }}
@@ -153,10 +153,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Clone ${{ matrix.project }} repository


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Current Gradle version should be running on Java >17. This also keeps version consistent for local development.

## Tested scenarios
Ran build locally

