### PR TITLE
fix(ci): adjust go generation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -67,76 +67,6 @@ jobs:
         commit-message: |
           ${{ (matrix.project == 'node' && '[reformat]') || '' }}[adyen-sdk-automation] automated change
   # split generation (create multiple PRs)
-  generate-modules:
-    runs-on: ubuntu-latest
-    # generate code as defined in the matrix
-    # each iteration generates a group of services and creates a PR
-    strategy:
-      matrix:
-        project: [ ]
-        tag: [PaymentsAPIs, ManagementAPIs, PlatformsAPIs, Webhooks]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Clone repository
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
-          repository: Adyen/adyen-${{ matrix.project }}-api-library
-          path: ${{ matrix.project }}/repo
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: ${{ matrix.project }} generate code for ${{ matrix.tag }}
-        env:
-          PROJECT: ${{ matrix.project }}
-          TAG: ${{ matrix.tag }}
-        run: ./gradlew $PROJECT:$TAG
-
-      - name: Set PR variables
-        id: vars
-        env:
-          TAG: ${{ matrix.tag }}
-        run: |
-          cd schema
-          echo "pr_title=[$TAG] Code generation: update services and models" >> "$GITHUB_OUTPUT"
-          echo pr_body="OpenAPI spec files or templates have been modified on $(date +%d-%m-%Y) by [commit](https://github.com/Adyen/adyen-openapi/commit/$(git rev-parse HEAD)). " >> "$GITHUB_OUTPUT"
-
-      - name: Check for changes
-        id: changes
-        env:
-          PROJECT: ${{ matrix.project }}
-        run: |
-          cd $PROJECT/repo
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      # create PR is there are changes    
-      - name: Create Pull Request
-        if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          path: ${{ matrix.project }}/repo
-          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
-          committer: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
-          author: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_EMAIL }}
-          # name branch accordingly
-          branch: sdk-automation/${{ matrix.tag }}
-          title: ${{ steps.vars.outputs.pr_title }}
-          body: ${{ steps.vars.outputs.pr_body }}
-          commit-message: |
-            [adyen-sdk-automation] automated changes
   generate-per-service:
     strategy:
       fail-fast: false
@@ -170,7 +100,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Override properties
-        if: matrix.project == 'node' || matrix.project == 'java' || matrix.project == 'python'  || matrix.project == 'ruby'
+        if: matrix.project != 'php'
         env:
           PROJECT: ${{ matrix.project }}
         run: cp $PROJECT/gradle.properties buildSrc

--- a/go/gradle.properties
+++ b/go/gradle.properties
@@ -1,0 +1,1 @@
+openapiGeneratorVersion=6.5.0


### PR DESCRIPTION
## Summary
- remove empty workflow setup (otherwise, the empty list of projects breaks the workflow)
- set generator version to be consistent to the version listed in the Makefile from Go

