### PR TITLE
.NET Generation: remove /docs generation

### DIFF
--- a/dotnet/build.gradle
+++ b/dotnet/build.gradle
@@ -203,30 +203,32 @@ services.each { Service svc ->
         into layout.projectDirectory.dir("repo/Adyen/${serviceName}/Extensions")
     }
 
-    // tmp removing /docs generation (to be enabled in a future release)
-//    def deployDocumentation = tasks.register("generate${svc.name}Documentation", Sync) {
-//        println "Moving ${svc.name}-Documentation..."
-//        group "generate"
-//        description "Move ${svc.name} into the repo."
-//        dependsOn "generate${svc.name}Services"
-//        outputs.upToDateWhen { false }
-//
-//        doFirst {
-//            // Delete existing /docs directory.
-//            delete layout.projectDirectory.dir("repo/docs/${serviceName}")
-//
-//            def docsDirectory = layout.projectDirectory.dir("repo/docs").getAsFile()
-//
-//            // Create /docs directory if it doesn't exist.
-//            if (!docsDirectory.exists()) {
-//                docsDirectory.mkdirs()
-//                println "Created /docs directory: ${docsDirectory}"
-//            }
-//        }
-//
-//        from(layout.buildDirectory.dir("services/$svc.id/docs/apis").get().asFile)
-//        into layout.projectDirectory.dir("repo/docs/${serviceName}")
-//    }
+    if (project.hasProperty('documentation.generation.enabled') && project.property('documentation.generation.enabled').toBoolean()) {
+        // generate docs (when flag is enabled)
+        def deployDocumentation = tasks.register("generate${svc.name}Documentation", Sync) {
+            println "Moving ${svc.name}-Documentation..."
+            group "generate"
+            description "Move ${svc.name} into the repo."
+            dependsOn "generate${svc.name}Services"
+            outputs.upToDateWhen { false }
+
+            doFirst {
+                // Delete existing /docs directory.
+                delete layout.projectDirectory.dir("repo/docs/${serviceName}")
+
+                def docsDirectory = layout.projectDirectory.dir("repo/docs").getAsFile()
+
+                // Create /docs directory if it doesn't exist.
+                if (!docsDirectory.exists()) {
+                    docsDirectory.mkdirs()
+                    println "Created /docs directory: ${docsDirectory}"
+                }
+            }
+
+            from(layout.buildDirectory.dir("services/$svc.id/docs/apis").get().asFile)
+            into layout.projectDirectory.dir("repo/docs/${serviceName}")
+        }
+    }
 
     def deployWebhookHandlers = tasks.register("generate${svc.name}WebhookHandlers") {
         group 'deploy'

--- a/dotnet/gradle.properties
+++ b/dotnet/gradle.properties
@@ -1,1 +1,3 @@
 openapiGeneratorVersion=7.16.0
+
+documentation.generation.enabled=false


### PR DESCRIPTION
This pull request temporarily disables the generation and deployment of documentation for each service in the `dotnet/build.gradle` build process. The main goal is to remove the `/docs` generation step, which will be re-enabled in a future release. All other deployment steps remain unaffected.

Build process changes:

* Commented out the `deployDocumentation` task in `dotnet/build.gradle`, preventing documentation from being moved into the `/repo/docs` directory for each service.
* Updated task dependencies so that the main service build task no longer depends on `deployDocumentation`, ensuring documentation is not generated or deployed during builds.