### PR TITLE
feat: add per-service generation log to target language repos

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -116,9 +116,30 @@ jobs:
 
       - name: Get OpenAPI commit SHA
         id: vars
+        env:
+          PROJECT: ${{ matrix.project }}
         run: |
           echo "sha=$(cd schema && git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "sha_short=$(cd schema && git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "library_sha=$(cd $PROJECT/repo && git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Write generation log
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PROJECT: ${{ matrix.project }}
+          SERVICE: ${{ matrix.service }}
+        run: |
+          mkdir -p $PROJECT/repo/sdk-generation-log
+          cat > $PROJECT/repo/sdk-generation-log/$SERVICE.json << EOF
+          {
+            "service": "$SERVICE",
+            "project": "$PROJECT",
+            "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "openapiCommitSha": "${{ steps.vars.outputs.sha }}",
+            "automationCommitSha": "${{ github.sha }}",
+            "libraryCommitSha": "${{ steps.vars.outputs.library_sha }}"
+          }
+          EOF
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
**Add per-service generation log to target language repos**

Each time the automation generates a PR for a language library, it now writes a small JSON file at `sdk-generation-log/{service}.json` inside that library's repository. The file is committed as part of the PR branch, so it is merged alongside the generated code.

**What is tracked**

```json
{
  "service": "checkout",
  "project": "java",
  "generatedAt": "2026-04-01T12:00:00Z",
  "openapiCommitSha": "abc123...",
  "automationCommitSha": "def456...",
  "libraryCommitSha": "ghi789..."
}
```

- `openapiCommitSha` — the exact commit of `adyen-openapi` the spec was generated from
- `automationCommitSha` — the exact commit of `adyen-sdk-automation` that ran the generation (Gradle tasks, parsing logic)
- `libraryCommitSha` — the exact commit of `adyen-{lang}-api-library` at generation time (templates, post-processing)

**Why one file per service**

Each matrix job operates on an isolated clone of the target repo, so there are no merge conflicts. A single shared file would require atomic compare-and-swap logic across parallel jobs.

**Reproducibility**

With all three SHAs available, any past generation can be reproduced exactly:

```bash
git -C adyen-sdk-automation checkout <automationCommitSha>
git -C adyen-sdk-automation/schema checkout <openapiCommitSha>
git -C adyen-java-api-library checkout <libraryCommitSha>
./gradlew :java:checkout
```