### PR TITLE
chore: remove @Adyen/developer-relations from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Adyen/developer-relations @Adyen/api-library-maintainers
+* @Adyen/api-library-maintainers


### PR DESCRIPTION
Removes `@Adyen/developer-relations` from the CODEOWNERS file, leaving `@Adyen/api-library-maintainers` as the sole code owner.