### PR TITLE
feat(ci): add detailed logging to change detection step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -106,9 +106,20 @@ jobs:
         working-directory: ${{ matrix.project }}/repo
         run: |
           # Check for modified tracked files AND new untracked files
+          echo "=== Git Status Output ==="
+          git status --porcelain
+          
           if [ -n "$(git status --porcelain)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected."
+            echo ""
+            echo "=== Changes Detected ==="
+            git status --porcelain | while IFS= read -r line; do
+              echo "  $line"
+            done
+            
+            echo ""
+            echo "=== Diff Summary ==="
+            git diff --stat
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected."

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -112,12 +112,6 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo ""
-            echo "=== Changes Detected ==="
-            git status --porcelain | while IFS= read -r line; do
-              echo "  $line"
-            done
-            
-            echo ""
             echo "=== Diff Summary ==="
             git diff --stat
           else


### PR DESCRIPTION
### Add logging to change detection step for debugging PR creation behavior
  
The `Check for changes` step currently only logs whether changes were detected, not *what* changed. This makes it hard to diagnose why PRs are being created or force-pushed when no meaningful code changes appear to exist. 

This commit adds `git status --porcelain` and `git diff --stat` output to the step logs so we can see exactly which files trigger PR creation going forward.