### PR TITLE
Introduce dependency change classifier to scope code generation runs

### DIFF
--- a/.github/scripts/should_generate.py
+++ b/.github/scripts/should_generate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""Classify whether a push may change generated SDK code.
+
+The generation workflow runs for changes to generator inputs and build
+infrastructure, while documentation and test-only updates are skipped to avoid
+unnecessary SDK pull requests. Ambiguous changes deliberately generate as a
+safe fallback, and the result is written in GitHub Actions output format.
+"""
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+TEST_DEPENDENCY = re.compile(r"\s*(?:testImplementation|testRuntimeOnly)\(")
+
+
+@dataclass(frozen=True)
+class Decision:
+    should_generate: bool
+    reason: str
+
+
+def git_output(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def is_test_dependency_only(repo: Path, before_sha: str, after_sha: str) -> bool:
+    diff = git_output(repo, "diff", "--unified=0", before_sha, after_sha, "--", "buildSrc/build.gradle.kts")
+    changed_lines = [
+        line[1:]
+        for line in diff.splitlines()
+        if line.startswith(("+", "-")) and not line.startswith(("+++ ", "--- "))
+    ]
+    return bool(changed_lines) and all(TEST_DEPENDENCY.match(line) for line in changed_lines)
+
+
+def is_missing_base_commit(repo: Path, before_sha: str) -> bool:
+    if re.fullmatch(r"0+", before_sha):
+        return True
+
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{before_sha}^{{commit}}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    ).returncode != 0
+
+
+def is_non_generation_file(path: str) -> bool:
+    return (
+        path in {"LICENSE", ".github/CODEOWNERS"}
+        or path.endswith(".md")
+        or path.startswith("buildSrc/src/test/")
+        or path.startswith(".github/scripts/test_")
+    )
+
+
+def classify_changes(before_sha: str, after_sha: str, repo: Path) -> Decision:
+    """Return the safe generation decision for the commit range."""
+    if is_missing_base_commit(repo, before_sha):
+        return Decision(True, "missing-base-commit")
+
+    changed_files = git_output(repo, "diff", "--name-only", before_sha, after_sha).splitlines()
+    if not changed_files:
+        return Decision(False, "no-changes")
+
+    for path in changed_files:
+        if is_non_generation_file(path):
+            continue
+        if path == "buildSrc/build.gradle.kts" and is_test_dependency_only(repo, before_sha, after_sha):
+            continue
+        return Decision(True, f"generation-affecting-change:{path}")
+
+    return Decision(False, "non-generation-changes-only")
+
+
+def write_output(decision: Decision, output_file: Path) -> None:
+    with output_file.open("a") as output:
+        output.write(f"should_generate={str(decision.should_generate).lower()}\n")
+        output.write(f"reason={decision.reason}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("before_sha")
+    parser.add_argument("after_sha")
+    parser.add_argument("output_file", type=Path)
+    args = parser.parse_args()
+
+    write_output(classify_changes(args.before_sha, args.after_sha, Path.cwd()), args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_resolve_matrix_inputs.py
+++ b/.github/scripts/test_resolve_matrix_inputs.py
@@ -21,6 +21,7 @@ ALL_SERVICES = [
     "disputes",
     "storedvalue",
     "payment",
+    "tapi",
     "management",
     "balancecontrol",
     "legalentitymanagement",

--- a/.github/scripts/test_should_generate.py
+++ b/.github/scripts/test_should_generate.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import tempfile
+import unittest
+import should_generate
+from pathlib import Path
+
+
+class TestShouldGenerate(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        self.run_git("init")
+        self.run_git("config", "user.email", "test@example.com")
+        self.run_git("config", "user.name", "Test User")
+        self.commit_changes({"README.md": "initial\n"})
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def commit_changes(self, changes: dict[str, str]) -> str:
+        for relative_path, content in changes.items():
+            path = self.repo / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        self.run_git("add", ".")
+        self.run_git("commit", "-m", "test change")
+        return self.run_git("rev-parse", "HEAD")
+
+    def classify(self, changes: dict[str, str]) -> dict[str, str]:
+        before = self.run_git("rev-parse", "HEAD")
+        after = self.commit_changes(changes)
+        decision = should_generate.classify_changes(before, after, self.repo)
+        return {
+            "should_generate": str(decision.should_generate).lower(),
+            "reason": decision.reason,
+        }
+
+    def test_cli_writes_github_outputs(self) -> None:
+        before = self.run_git("rev-parse", "HEAD")
+        after = self.commit_changes({"README.md": "documentation\n"})
+        output_path = self.repo / "output.txt"
+        subprocess.run(
+            [sys.executable, should_generate.__file__, before, after, str(output_path)],
+            cwd=self.repo,
+            check=True,
+        )
+        result = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+
+        self.assertEqual(result["should_generate"], "false")
+        self.assertEqual(result["reason"], "non-generation-changes-only")
+
+    def test_skips_test_dependency_only_update(self) -> None:
+        result = self.classify(
+            {
+                "buildSrc/build.gradle.kts": (
+                    'testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")\n'
+                    'testRuntimeOnly("org.junit.platform:junit-platform-launcher")\n'
+                )
+            }
+        )
+
+        self.assertEqual(result["should_generate"], "false")
+        self.assertEqual(result["reason"], "non-generation-changes-only")
+
+    def test_generates_for_openapi_generator_dependency_update(self) -> None:
+        result = self.classify(
+            {
+                "buildSrc/build.gradle.kts": (
+                    'implementation("org.openapitools:openapi-generator-gradle-plugin:7.16.0")\n'
+                )
+            }
+        )
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(result["reason"], "generation-affecting-change:buildSrc/build.gradle.kts")
+
+    def test_generates_for_generator_source_change(self) -> None:
+        result = self.classify({"buildSrc/src/main/kotlin/Service.kt": "class Service\n"})
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(result["reason"], "generation-affecting-change:buildSrc/src/main/kotlin/Service.kt")
+
+    def test_generates_for_language_configuration_change(self) -> None:
+        result = self.classify({"java/config.yaml": "library: jersey3\n"})
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(result["reason"], "generation-affecting-change:java/config.yaml")
+
+    def test_generates_for_gradle_wrapper_change(self) -> None:
+        result = self.classify({"gradle/wrapper/gradle-wrapper.properties": "distributionUrl=gradle-9.6-bin.zip\n"})
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(
+            result["reason"],
+            "generation-affecting-change:gradle/wrapper/gradle-wrapper.properties",
+        )
+
+    def test_skips_documentation_and_tests(self) -> None:
+        result = self.classify(
+            {
+                "README.md": "documentation\n",
+                "buildSrc/src/test/kotlin/ServiceTest.kt": "class ServiceTest\n",
+            }
+        )
+
+        self.assertEqual(result["should_generate"], "false")
+        self.assertEqual(result["reason"], "non-generation-changes-only")
+
+    def test_skips_mixed_test_dependency_and_documentation_update(self) -> None:
+        result = self.classify(
+            {
+                "README.md": "documentation\n",
+                "buildSrc/build.gradle.kts": 'testImplementation("org.assertj:assertj-core:3.27.7")\n',
+            }
+        )
+
+        self.assertEqual(result["should_generate"], "false")
+        self.assertEqual(result["reason"], "non-generation-changes-only")
+
+    def test_generates_for_ambiguous_build_file_change(self) -> None:
+        result = self.classify({"buildSrc/build.gradle.kts": "repositories { mavenCentral() }\n"})
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(result["reason"], "generation-affecting-change:buildSrc/build.gradle.kts")
+
+    def test_generates_for_unknown_change(self) -> None:
+        result = self.classify({"renovate.json": "{}\n"})
+
+        self.assertEqual(result["should_generate"], "true")
+        self.assertEqual(result["reason"], "generation-affecting-change:renovate.json")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,11 +13,6 @@ on:
         default: ''
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - '**/README.md'
-      - README.md
-      - LICENSE
-      - .github/CODEOWNERS
 
 permissions:
   contents: read
@@ -32,8 +27,29 @@ jobs:
     outputs:
       projects: ${{ steps.resolve.outputs.projects }}
       services: ${{ steps.resolve.outputs.services }}
+      should_generate: ${{ steps.classify.outputs.should_generate }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify generation impact
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_generate=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual-dispatch" >> "$GITHUB_OUTPUT"
+          else
+            python3 .github/scripts/should_generate.py "$BEFORE_SHA" "$AFTER_SHA" "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report generation decision
+        run: |
+          echo "SDK generation: ${{ steps.classify.outputs.should_generate }} (${{ steps.classify.outputs.reason }})" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Resolve matrix inputs
         id: resolve
@@ -45,6 +61,7 @@ jobs:
   # split generation (create multiple PRs)
   generate-per-service:
     needs: setup
+    if: needs.setup.outputs.should_generate == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/buildSrc/src/test/java/com/adyen/sdk/SdkAutomationConventionsTest.java
+++ b/buildSrc/src/test/java/com/adyen/sdk/SdkAutomationConventionsTest.java
@@ -3,8 +3,6 @@ package com.adyen.sdk;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
-import org.openapitools.generator.gradle.plugin.tasks.GenerateTask;
-import com.adyen.sdk.SdkAutomationExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Currently we generate PRs to all SDK repos even for test dependency updates, which introduces extra noise and wastes resources. We should only generate if there are meaningful changes to the generation logic & dependencies.
