### PR TITLE
Add mvn spotless java generate service

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -159,8 +159,20 @@ services.forEach { svc ->
         }
     }
 
-    tasks.named(svc.id) {
+    // Format deployed code with spotless
+    val spotless = tasks.register<Exec>("spotless${svc.name}") {
+        group = "deploy"
+        description = "Run spotless:apply on generated ${svc.name} code."
         dependsOn(deployModels, deployServices, deploySerializers, deployWebhookHandlers)
+        workingDir(layout.projectDirectory.dir("repo"))
+        commandLine(
+            "mvn", "spotless:apply",
+            "-DspotlessFiles=.*com/adyen/(model|service)/${serviceId}/.*"
+        )
+    }
+
+    tasks.named(svc.id) {
+        dependsOn(deployModels, deployServices, deploySerializers, deployWebhookHandlers, spotless)
     }
 }
 


### PR DESCRIPTION

## Summary
 This PR adds a Maven Spotless formatting step to the Java service generation pipeline.

## Description:
Adds a `spotless<Service>` Gradle task that runs `mvn spotless:apply` on each generated Java  service's code (scoped to its `model`/`service` files), and wires it into the per-service generation task so freshly generated code is automatically formatted before completion.
