### PR TITLE
Feature: Add string escaping in ruby via custom lambda

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,6 +14,7 @@ val openapiGeneratorVersion: String = System.getProperty("openapiGeneratorVersio
 
 dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:$openapiGeneratorVersion")
+    implementation("org.openapitools:openapi-generator:$openapiGeneratorVersion")
     implementation(localGroovy())
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
     testImplementation("org.assertj:assertj-core:3.27.7")

--- a/buildSrc/src/main/kotlin/com/adyen/sdk/AdyenRubyCodegen.kt
+++ b/buildSrc/src/main/kotlin/com/adyen/sdk/AdyenRubyCodegen.kt
@@ -1,0 +1,15 @@
+package com.adyen.sdk
+
+import org.openapitools.codegen.languages.RubyClientCodegen
+
+/**
+ * Ruby client generator with Adyen-specific Mustache lambdas on top of the
+ * stock Ruby generator. Referenced by its fully-qualified class name as the
+ * `generatorName` of the Ruby generate tasks.
+ */
+class AdyenRubyCodegen : RubyClientCodegen() {
+    override fun processOpts() {
+        super.processOpts()
+        additionalProperties["lambda.escapeSingleQuotedString"] = EscapeSingleQuotedStringLambda()
+    }
+}

--- a/buildSrc/src/main/kotlin/com/adyen/sdk/EscapeSingleQuotedStringLambda.kt
+++ b/buildSrc/src/main/kotlin/com/adyen/sdk/EscapeSingleQuotedStringLambda.kt
@@ -1,0 +1,26 @@
+package com.adyen.sdk
+
+import com.samskivert.mustache.Mustache
+import com.samskivert.mustache.Template
+import java.io.Writer
+
+/**
+ * Mustache lambda that escapes its rendered content for inclusion in a Ruby
+ * single-quoted string literal.
+ *
+ * Usage in templates: {{#lambda.escapeSingleQuotedString}}...{{/lambda.escapeSingleQuotedString}}
+ *
+ * Unlike Mustache's built-in {{.}} escaping (which targets HTML and would turn
+ * e.g. backticks into &#x60;), this escapes only what Ruby single-quoted syntax
+ * recognizes: backslashes and single quotes.
+ */
+class EscapeSingleQuotedStringLambda : Mustache.Lambda {
+    override fun execute(fragment: Template.Fragment, writer: Writer) {
+        val escaped = fragment.execute()
+            // Backslash first: it doubles only pre-existing backslashes, so the
+            // quote escape introduced below is never re-processed.
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+        writer.write(escaped)
+    }
+}

--- a/buildSrc/src/test/kotlin/com/adyen/sdk/EscapeSingleQuotedStringLambdaTest.kt
+++ b/buildSrc/src/test/kotlin/com/adyen/sdk/EscapeSingleQuotedStringLambdaTest.kt
@@ -1,0 +1,57 @@
+package com.adyen.sdk
+
+import com.samskivert.mustache.Mustache
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EscapeSingleQuotedStringLambdaTest {
+
+    private fun render(message: String): String {
+        // inner must be triple-braced (raw), otherwise jmustache HTML-escapes
+        // the content before the lambda sees it
+        val template = Mustache.compiler()
+            .compile("{{#lambda.escapeSingleQuotedString}}{{{message}}}{{/lambda.escapeSingleQuotedString}}")
+        val context = mapOf(
+            "lambda.escapeSingleQuotedString" to EscapeSingleQuotedStringLambda(),
+            "message" to message
+        )
+        return template.execute(context)
+    }
+
+    @Test
+    fun `escapes single quotes`() {
+        assertThat(render("Use Adyen's API instead."))
+            .isEqualTo("Use Adyen\\'s API instead.")
+    }
+
+    @Test
+    fun `escapes backslashes`() {
+        assertThat(render("C:\\temp")).isEqualTo("C:\\\\temp")
+    }
+
+    @Test
+    fun `escapes a backslash before an already-escaped quote`() {
+        // input is backslash + quote (2 chars); the backslash rule runs first,
+        // so the result round-trips to the original value in Ruby
+        assertThat(render("a\\'b")).isEqualTo("a\\\\\\'b")
+    }
+
+    @Test
+    fun `leaves double quotes and interpolation sequences untouched`() {
+        // inert in single-quoted literals: " needs no escape, #{...} is not interpolated
+        assertThat(render("Use \"payments\" #{here} instead."))
+            .isEqualTo("Use \"payments\" #{here} instead.")
+    }
+
+    @Test
+    fun `leaves line breaks untouched`() {
+        // legal in single-quoted literals; escaping to \n would corrupt the value
+        assertThat(render("first\nsecond")).isEqualTo("first\nsecond")
+    }
+
+    @Test
+    fun `leaves markdown and other prose untouched`() {
+        val message = "Use the `/grants` endpoint from the [Capital API](https://docs.adyen.com/api-explorer/capital) instead."
+        assertThat(render(message)).isEqualTo(message)
+    }
+}

--- a/ruby/build.gradle.kts
+++ b/ruby/build.gradle.kts
@@ -17,6 +17,8 @@ services.forEach { svc ->
 
     // Generation
     tasks.named<GenerateTask>("generate${svc.name}") {
+        // Custom generator adding Adyen-specific Mustache lambdas (e.g. lambda.escapeSingleQuotedString)
+        generatorName.set("com.adyen.sdk.AdyenRubyCodegen")
         configFile.set("$projectDir/config.yaml")
 
         additionalProperties.putAll(mapOf(


### PR DESCRIPTION
Single-quoted strings in Ruby are typically treated as literal. However, the two exceptions are `'` and `\`. 

Added a custom lambda to ensure that these special characters are also escaped.